### PR TITLE
fix: Make forest-docs base url absolute

### DIFF
--- a/src/components/OperationClass/OperationClass.tsx
+++ b/src/components/OperationClass/OperationClass.tsx
@@ -21,6 +21,7 @@ import {
   Link as BoemlyLink,
 } from 'boemly';
 import { TableWrapper } from '../TableWrapper';
+import { FOREST_DOCS_URI } from '../../constants/integrations';
 
 interface Species {
   /** Free text title of the species */
@@ -90,7 +91,10 @@ export const OperationClass: React.FC<OperationClassProps> = ({
                 <Tr key={index}>
                   <Td>{species.title}</Td>
                   <Td>
-                    <BoemlyLink as={Link} href={`/yieldTables/${species.yieldTable}`}>
+                    <BoemlyLink
+                      as={Link}
+                      href={`${FOREST_DOCS_URI}/yieldTables/${species.yieldTable}`}
+                    >
                       {yieldTables[species.yieldTable].meta.title}
                     </BoemlyLink>
                   </Td>

--- a/src/constants/integrations.ts
+++ b/src/constants/integrations.ts
@@ -1,0 +1,1 @@
+export const FOREST_DOCS_URI = 'https://forest-docs.tree.ly';


### PR DESCRIPTION
Does not have to be configurable since there is no real staging env for the forest-docs project.