### PR TITLE
build(dependencies): Clean up package requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     ]
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=16 <=18"
   },
   "size-limit": [
     {
@@ -108,8 +108,7 @@
     "boemly": "^5.3.0"
   },
   "peerDependencies": {
-    "next": ">=11",
-    "react": ">=16",
+    "react": ">=18",
     "react-intl": ">=6"
   }
 }

--- a/src/components/OperationClass/OperationClass.tsx
+++ b/src/components/OperationClass/OperationClass.tsx
@@ -1,5 +1,4 @@
 import { useContext, useMemo } from 'react';
-import Link from 'next/link';
 import yieldTables from '../../constants/yieldTables';
 import AreaInHectare from '../../models/AreaInHectare';
 import AreaInPercent from '../../models/AreaInPercent';
@@ -92,7 +91,7 @@ export const OperationClass: React.FC<OperationClassProps> = ({
                   <Td>{species.title}</Td>
                   <Td>
                     <BoemlyLink
-                      as={Link}
+                      as="a"
                       href={`${FOREST_DOCS_URI}/yieldTables/${species.yieldTable}`}
                     >
                       {yieldTables[species.yieldTable].meta.title}


### PR DESCRIPTION
BREAKING CHANGE: Dropped supported React and Node versions.

- Only allow React versions >=18
- Drop Next.js as a peer dependency
- Only allow Node versions 16 - 18